### PR TITLE
Remove stray character from targets configuration

### DIFF
--- a/targets.txt
+++ b/targets.txt
@@ -20,4 +20,3 @@ SPAI class=risky buy=1.8 sell=1.0
 # If you want fixed clip sizing for a name, add clip=...
 # Example:
 # RCAT class=risky buy=1.8 sell=1.0 clip=1500
-s


### PR DESCRIPTION
## Summary
- remove the stray `s` character appended to the bottom of `targets.txt`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e687012d2c8326b5668453f8b23d8f