### PR TITLE
Automate ladder rungs with scaled clips

### DIFF
--- a/targets.txt
+++ b/targets.txt
@@ -7,15 +7,15 @@
 #   sell  = % above ref to TRIM
 #   clip  = USD per buy (omit to use dynamic sizing)
 
-RCAT class=risky buy=1.8 sell=1.0
-DPRO class=risky buy=1.8 sell=1.0
-UMAC class=risky buy=1.8 sell=1.0
-AVAV class=safe  buy=1.2 sell=0.8
-KTOS class=safe  buy=1.2 sell=0.8
-LPTH class=risky buy=1.8 sell=1.0
-ONDS class=risky buy=1.8 sell=1.0
-EH   class=risky buy=1.8 sell=1.0
-SPAI class=risky buy=1.8 sell=1.0
+RCAT class=risky buy=0.9 sell=1.0
+DPRO class=risky buy=0.9 sell=1.0
+UMAC class=risky buy=0.9 sell=1.0
+AVAV class=safe  buy=0.6 sell=0.8
+KTOS class=safe  buy=0.6 sell=0.8
+LPTH class=risky buy=0.9 sell=1.0
+ONDS class=risky buy=0.9 sell=1.0
+EH   class=risky buy=0.9 sell=1.0
+SPAI class=risky buy=0.9 sell=1.0
 
 # If you want fixed clip sizing for a name, add clip=...
 # Example:


### PR DESCRIPTION
## Summary
- drive all three ladder rungs automatically, scaling clip size as price moves deeper and unwinding in reverse when price rebounds
- gate the multi-rung logic with the existing VWV momentum checks and track ladder layer state in the HUD output
- retune dynamic clip sizing for roughly two-thirds equity utilization and document the new ladder behavior

## Testing
- python -m compileall dronebot.py

------
https://chatgpt.com/codex/tasks/task_e_68e6877c01c88326ada5514ec65efc87